### PR TITLE
Add calendar, travel, local info, and geolocation MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ flutter run
 - **State Management**: Provider
 - **Database**: ObjectBox
 
+## 🌐 MCP Servers
+
+This repository includes example MCP servers that expose additional tools over
+WebSockets.
+
+- **Weather MCP** (`lib/mcp/mcp_server.py`) provides weather forecasts (port
+  8080).
+- **Jokes MCP** (`lib/mcp/jokes_mcp_server.py`) returns a random programming
+  joke via the `get-joke` tool (port 8081).
+- **Calendar MCP** (`lib/mcp/calendar_mcp_server.py`) schedules meetings (port
+  8082).
+- **Travel MCP** (`lib/mcp/travel_mcp_server.py`) plans travel itineraries
+  (port 8083).
+- **Local Info MCP** (`lib/mcp/local_info_mcp_server.py`) suggests nearby
+  points of interest (port 8084).
+- **Geolocation MCP** (`lib/mcp/geolocation_mcp_server.py`) resolves IP
+  addresses to a location (port 8085).
+
+Run a server with:
+
+```bash
+pip install aiohttp websockets
+python lib/mcp/<server_file>.py
+```
+
+
 ## 🤝 Contributing
 
 We welcome contributions! Please follow these steps:

--- a/lib/mcp/calendar_mcp_server.py
+++ b/lib/mcp/calendar_mcp_server.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from websockets import serve
+
+class McpServer:
+    def __init__(self):
+        self.tools: dict[str, dict] = {}
+        self.pending_requests: dict = {}
+
+    def tool(self, name: str, description: str, input_schema: dict, callback):
+        self.tools[name] = {
+            "description": description,
+            "input_schema": input_schema,
+            "callback": callback,
+        }
+
+    async def handle_connection(self, websocket):
+        print(f"New connection from {websocket.remote_address}")
+        async for message in websocket:
+            try:
+                print(f"Received: {message}")
+                data = json.loads(message)
+                request_id = data.get("id")
+                method = data.get("method")
+                params = data.get("params", {})
+
+                if method in self.tools:
+                    result = await self.tools[method]["callback"](params)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"content": [{"text": result}]},
+                    }
+                else:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": f"Method '{method}' not found"},
+                    }
+                print(f"Sending: {json.dumps(response)}")
+                await websocket.send(json.dumps(response))
+            except Exception as e:
+                print(f"Error handling request: {e}")
+
+async def schedule_meeting(params):
+    event = params.get("event", "meeting")
+    date = params.get("date", "unspecified date")
+    time = params.get("time", "unspecified time")
+    return f"Scheduled {event} on {date} at {time}."
+
+async def main():
+    server = McpServer()
+    server.tool(
+        name="schedule-meeting",
+        description="Schedule or reschedule a meeting",
+        input_schema={
+            "event": {"type": "string", "description": "Event title"},
+            "date": {"type": "string", "description": "Date of event"},
+            "time": {"type": "string", "description": "Time of event"},
+        },
+        callback=schedule_meeting,
+    )
+
+    async with serve(server.handle_connection, "0.0.0.0", 8082):
+        print("Calendar MCP running on ws://0.0.0.0:8082")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lib/mcp/geolocation_mcp_server.py
+++ b/lib/mcp/geolocation_mcp_server.py
@@ -1,0 +1,67 @@
+import asyncio
+import json
+from websockets import serve
+
+class McpServer:
+    def __init__(self):
+        self.tools: dict[str, dict] = {}
+        self.pending_requests: dict = {}
+
+    def tool(self, name: str, description: str, input_schema: dict, callback):
+        self.tools[name] = {
+            "description": description,
+            "input_schema": input_schema,
+            "callback": callback,
+        }
+
+    async def handle_connection(self, websocket):
+        print(f"New connection from {websocket.remote_address}")
+        async for message in websocket:
+            try:
+                print(f"Received: {message}")
+                data = json.loads(message)
+                request_id = data.get("id")
+                method = data.get("method")
+                params = data.get("params", {})
+
+                if method in self.tools:
+                    result = await self.tools[method]["callback"](params)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"content": [{"text": result}]},
+                    }
+                else:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": f"Method '{method}' not found"},
+                    }
+                print(f"Sending: {json.dumps(response)}")
+                await websocket.send(json.dumps(response))
+            except Exception as e:
+                print(f"Error handling request: {e}")
+
+async def get_location(params):
+    ip = params.get("ip", "127.0.0.1")
+    mapping = {
+        "127.0.0.1": {"latitude": 37.7749, "longitude": -122.4194, "city": "San Francisco"}
+    }
+    loc = mapping.get(ip, {"latitude": 0.0, "longitude": 0.0, "city": "Unknown"})
+    return json.dumps(loc)
+
+async def main():
+    server = McpServer()
+    server.tool(
+        name="get-location",
+        description="Lookup approximate location for an IP address",
+        input_schema={"ip": {"type": "string", "description": "IPv4 address"}},
+        callback=get_location,
+    )
+
+    async with serve(server.handle_connection, "0.0.0.0", 8085):
+        print("Geolocation MCP running on ws://0.0.0.0:8085")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lib/mcp/jokes_mcp_server.py
+++ b/lib/mcp/jokes_mcp_server.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+import random
+from websockets import serve
+
+class McpServer:
+    def __init__(self):
+        self.tools: dict[str, dict] = {}
+        self.pending_requests: dict = {}
+
+    def tool(self, name: str, description: str, input_schema: dict, callback):
+        self.tools[name] = {
+            "description": description,
+            "input_schema": input_schema,
+            "callback": callback,
+        }
+
+    async def handle_connection(self, websocket):
+        print(f"New connection from {websocket.remote_address}")
+        async for message in websocket:
+            try:
+                print(f"Received: {message}")
+                data = json.loads(message)
+                request_id = data.get("id")
+                method = data.get("method")
+                params = data.get("params", {})
+
+                if method in self.tools:
+                    result = await self.tools[method]["callback"](params)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"content": [{"text": result}]},
+                    }
+                else:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": f"Method '{method}' not found"},
+                    }
+                print(f"Sending: {json.dumps(response)}")
+                await websocket.send(json.dumps(response))
+            except Exception as e:
+                print(f"Error handling request: {e}")
+
+async def get_random_joke(params):
+    jokes = [
+        "Why do Java developers wear glasses? Because they don't C#.",
+        "How many programmers does it take to change a light bulb? None. It's a hardware problem.",
+        "A SQL query walks into a bar and sees two tables. It asks, 'Can I join you?'",
+        "There are 10 kinds of people: those who understand binary and those who don't.",
+    ]
+    return random.choice(jokes)
+
+async def main():
+    server = McpServer()
+    server.tool(
+        name="get-joke",
+        description="Return a random programming joke",
+        input_schema={},
+        callback=get_random_joke,
+    )
+
+    async with serve(server.handle_connection, "0.0.0.0", 8081):
+        print("Jokes MCP running on ws://0.0.0.0:8081")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lib/mcp/local_info_mcp_server.py
+++ b/lib/mcp/local_info_mcp_server.py
@@ -1,0 +1,71 @@
+import asyncio
+import json
+from websockets import serve
+
+class McpServer:
+    def __init__(self):
+        self.tools: dict[str, dict] = {}
+        self.pending_requests: dict = {}
+
+    def tool(self, name: str, description: str, input_schema: dict, callback):
+        self.tools[name] = {
+            "description": description,
+            "input_schema": input_schema,
+            "callback": callback,
+        }
+
+    async def handle_connection(self, websocket):
+        print(f"New connection from {websocket.remote_address}")
+        async for message in websocket:
+            try:
+                print(f"Received: {message}")
+                data = json.loads(message)
+                request_id = data.get("id")
+                method = data.get("method")
+                params = data.get("params", {})
+
+                if method in self.tools:
+                    result = await self.tools[method]["callback"](params)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"content": [{"text": result}]},
+                    }
+                else:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": f"Method '{method}' not found"},
+                    }
+                print(f"Sending: {json.dumps(response)}")
+                await websocket.send(json.dumps(response))
+            except Exception as e:
+                print(f"Error handling request: {e}")
+
+async def find_nearby(params):
+    location = params.get("location", "your area")
+    category = params.get("category", "points of interest")
+    suggestions = [
+        f"Sample {category} A near {location}",
+        f"Sample {category} B near {location}",
+    ]
+    return "\n".join(suggestions)
+
+async def main():
+    server = McpServer()
+    server.tool(
+        name="find-nearby",
+        description="Suggest nearby restaurants, cafés, or landmarks",
+        input_schema={
+            "location": {"type": "string", "description": "City or coordinates"},
+            "category": {"type": "string", "description": "Type of place"},
+        },
+        callback=find_nearby,
+    )
+
+    async with serve(server.handle_connection, "0.0.0.0", 8084):
+        print("Local Info MCP running on ws://0.0.0.0:8084")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lib/mcp/travel_mcp_server.py
+++ b/lib/mcp/travel_mcp_server.py
@@ -1,0 +1,67 @@
+import asyncio
+import json
+from websockets import serve
+
+class McpServer:
+    def __init__(self):
+        self.tools: dict[str, dict] = {}
+        self.pending_requests: dict = {}
+
+    def tool(self, name: str, description: str, input_schema: dict, callback):
+        self.tools[name] = {
+            "description": description,
+            "input_schema": input_schema,
+            "callback": callback,
+        }
+
+    async def handle_connection(self, websocket):
+        print(f"New connection from {websocket.remote_address}")
+        async for message in websocket:
+            try:
+                print(f"Received: {message}")
+                data = json.loads(message)
+                request_id = data.get("id")
+                method = data.get("method")
+                params = data.get("params", {})
+
+                if method in self.tools:
+                    result = await self.tools[method]["callback"](params)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"content": [{"text": result}]},
+                    }
+                else:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": f"Method '{method}' not found"},
+                    }
+                print(f"Sending: {json.dumps(response)}")
+                await websocket.send(json.dumps(response))
+            except Exception as e:
+                print(f"Error handling request: {e}")
+
+async def plan_trip(params):
+    start = params.get("start", "your location")
+    destination = params.get("destination", "unknown destination")
+    return f"Planned itinerary from {start} to {destination}."
+
+async def main():
+    server = McpServer()
+    server.tool(
+        name="plan-trip",
+        description="Plan travel itinerary",
+        input_schema={
+            "start": {"type": "string", "description": "Start location"},
+            "destination": {"type": "string", "description": "Destination"},
+        },
+        callback=plan_trip,
+    )
+
+    async with serve(server.handle_connection, "0.0.0.0", 8083):
+        print("Travel MCP running on ws://0.0.0.0:8083")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add Calendar MCP server for scheduling meetings
- add Travel MCP server for itineraries
- add Local Info MCP server with location suggestions
- add Geolocation MCP server for IP lookups
- document running all MCP servers in README
- note Python dependencies for MCP servers

## Testing
- `python -m py_compile lib/mcp/calendar_mcp_server.py lib/mcp/travel_mcp_server.py lib/mcp/local_info_mcp_server.py lib/mcp/geolocation_mcp_server.py lib/mcp/jokes_mcp_server.py lib/mcp/mcp_server.py`
- `flutter test` *(fails: command not found)*
- `python lib/mcp/jokes_mcp_server.py` *(runs and prints server start message)*

------
https://chatgpt.com/codex/tasks/task_e_68454f908b088332b0748a2d37c3bb1c